### PR TITLE
CASMPET-5873: use the new base chart for CVE fix

### DIFF
--- a/charts/v1.0/cray-nls/Chart.yaml
+++ b/charts/v1.0/cray-nls/Chart.yaml
@@ -24,18 +24,18 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.3.7
+version: 1.3.8
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:
   - "https://github.com/Cray-HPE/cray-nls"
 dependencies:
   - name: cray-service
-    version: "8.2.0"
+    version: ~8.2.0
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
     alias: cray-service-pg-only
   - name: cray-service
-    version: "8.2.0"
+    version: ~8.2.0
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
     alias: cray-service
   - name: argo-workflows


### PR DESCRIPTION
## Summary and Scope

Use the new base chart to pull in security fixes in the latest postgres-db-backup image. Bumped the chart patch version.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [[CASMPET-5873](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5873)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

