### PR TITLE
CASMPET-5916 add separate mount in cray-nls for storage workflows

### DIFF
--- a/charts/v1.0/cray-nls/Chart.yaml
+++ b/charts/v1.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.3.8
+version: 1.4.0
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v1.0/cray-nls/templates/configmap.yaml
+++ b/charts/v1.0/cray-nls/templates/configmap.yaml
@@ -5,3 +5,11 @@ metadata:
 data:
   readme: |
     Config map to store worker rebuild workflow files    
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: storage-rebuild-workflow-files
+data:
+  readme: |
+    Config map to store storage rebuild workflow files

--- a/charts/v1.0/cray-nls/values.yaml
+++ b/charts/v1.0/cray-nls/values.yaml
@@ -36,6 +36,9 @@ cray-service:
     - name: worker-rebuild-workflow-files
       configMap:
         name: worker-rebuild-workflow-files
+    - name: storage-rebuild-workflow-files
+      configMap:
+        name: storage-rebuild-workflow-files
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -72,6 +75,9 @@ cray-service:
         - name: worker-rebuild-workflow-files
           readOnly: true
           mountPath: /workflows/worker/ncn
+        - name: storage-rebuild-workflow-files
+          readOnly: true
+          mountPath: /workflows/storage/ncn
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
@@ -100,7 +106,7 @@ cray-service:
         - name: WORKER_REBUILD_WORKFLOW_FILES
           value: "/workflows/worker"
         - name: STORAGE_REBUILD_WORKFLOW_FILES
-          value: "/workflows/worker"
+          value: "/workflows/storage"
       ports:
         - name: http
           containerPort: 3000


### PR DESCRIPTION
## Summary and Scope

add separate mount in cray-nls for storage workflows

Tested on vShasta with --dry-run to check for correct configuration.

## Issues and Related PRs

* Related moving storage workflow in docs: https://github.com/Cray-HPE/docs-csm/pull/2340

## Risks and Mitigations
 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

