### PR TITLE
CASMPET-6086 CSM 1.2.2 : BREAK/FIX: Cray-nls rebuild to pick up cray-services:8.1.5

### DIFF
--- a/charts/v1.0/cray-nls/Chart.yaml
+++ b/charts/v1.0/cray-nls/Chart.yaml
@@ -24,18 +24,18 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.2.5
+version: 1.2.7
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:
   - "https://github.com/Cray-HPE/cray-nls"
 dependencies:
   - name: cray-service
-    version: "8.1.3"
+    version: "8.1.5"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
     alias: cray-service-pg-only
   - name: cray-service
-    version: "8.1.3"
+    version: "8.1.5"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
     alias: cray-service
   - name: argo-workflows


### PR DESCRIPTION
## Summary and Scope

BREAK/FIX: Cray-nls needs to pick up the cray base chart version 8.1.5 to fix postgres restore incompatibility issue in CSM 1.2.2

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6086](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6086)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

