### PR TITLE
CASMINST-5876: Bump cray-nls container version

### DIFF
--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.4.50
+version: 1.4.51
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.9.18
+        tag: 0.9.19
       resources:
         limits:
           cpu: 1


### PR DESCRIPTION
## Summary and Scope

Bump cray-nls container image version to 0.9.19 to pull in `vcs.repo_name` support.

## Issues and Related PRs

* Resolves [CASMINST-5876](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5876)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

