### PR TITLE
CASMINST-5679: Update version of cray-nls in chart

### DIFF
--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.4.54
+version: 1.4.55
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.9.23
+        tag: 0.10.0
       resources:
         limits:
           cpu: 1


### PR DESCRIPTION
Update the version of the cray-nls container image specified in the cray-nls chart to 0.10.0 and bump the chart version.

## Summary and Scope

Update the version of the cray-nls container image specified in the cray-nls chart to 0.10.0 and bump the chart version.

## Issues and Related PRs

* Resolves [CASMINST-5679](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5679)

## Testing

### Tested on:

  * Local development environment

### Test description:

See https://github.com/Cray-HPE/cray-nls/pull/158

## Risks and Mitigations

Low risk.

See https://github.com/Cray-HPE/cray-nls/pull/158


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

