### PR TITLE
CASMINST-5851

### DIFF
--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.4.56
+version: 1.4.57
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/templates/metacontrollers.yaml
+++ b/charts/v2.0/cray-nls/templates/metacontrollers.yaml
@@ -57,4 +57,5 @@ spec:
     sync:
       webhook:
         url: "http://{{ index .Values "argo-host" }}/apis/iuf/v1/session/sync"
+        timeout: 30s
 

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.1
+        tag: 0.10.2
       resources:
         limits:
           cpu: 1


### PR DESCRIPTION
## Summary and Scope

Finally fixes [CASMINST-5851](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5851)

The previous fix didn't work on lemondrop.

I hot-patched a new fix on lemondrop and let it run for a few days. It seems the new fix that was hot-patched has not produced any duplicate workflows.

About the new fix: it tweaks the timeout value for metacontroller from 10s to 30s. This gives enough time for the first call to complete on large stages such as deliver-product.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5851](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5851)

## Testing

lemondrop

### Test description:

Ran `IUF run` multiple times and didn't notice any duplicate workflows.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

