### PR TITLE
CASMPET-6323 and CASMINST-5988

### DIFF
--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.4.58
+version: 1.4.59
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.3
+        tag: 0.10.4
       resources:
         limits:
           cpu: 1


### PR DESCRIPTION
## Summary and Scope

This PR contains fixes for the following two issues:
* [CASMPET-6323](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6323) IUF abort taking a long time / hanging when pressing Ctrl+C
* [CASMINST-5988](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5988) BREAK/FIX: management-node-rollout breaks with "default" product containing jinja templates

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves:
  * [CASMPET-6323](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6323)
  * [CASMINST-5988](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5988)
* Change will also be needed in docs-csm, cray-nls, cray-nls-charts, csm

## Testing

gamora, lemondrop

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Adhoc testing

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

