### PR TITLE
CASMTRIAGE-5124 patch activity doesn't truly work like patch activity

### DIFF
--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 1.4.64
+version: 1.4.65
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.8
+        tag: 0.10.9
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.0.1  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.0.2  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls/charts/v1.0/cray-iuf"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.0.1  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.0.2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.8
+        tag: 0.10.9
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -12,6 +12,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "3.0.0": "0.0.1"
   "3.0.1": "0.0.1"
+  "3.0.2": "0.0.1"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Issue: Try to run management node rollout with Management_Master first, then Management_Worker next. The second run doesn't work, and it keeps trying to do Management_Master.

Root cause: Patch activity was not implemented as a true patching capability ... it was basically replacing input parameters whenever it received a patch request where the input parameters at least had the media directory set. In a particular case, the admin was not even specifying media directory on the command line, and hence because of the absence of media directory, the change from Management_Master to Management_Worker was not being persisted.

Fix: Use proper patching capability, where a struct with pointers is used to unmarshal the incoming json so that we can detect the difference between an empty value that was part of the JSON patch and a nil pointer which means nothing was set for that attribute.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5124](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5124)

## Testing

Tested on Gamora and wrote unit tests.

### Test description:

Tried to reproduce before the fix and after.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

