### PR TITLE
CASMINST-6208 bump cray-nls version to 0.10.11

### DIFF
--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.1  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.2  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.1  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.10
+        tag: 0.10.11
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -58,7 +58,7 @@ chartValidationLog:
   date: 2023-05-05
 - chartVersion: 3.2.0
   csm: 1.5.0
-  environment: 
-  result:
-  tester:
-  date: 
+  environment: dorian (vshasta)
+  result: PASS
+  tester: leliasen-hpe
+  date: 2023-06-01

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -17,6 +17,7 @@ chartVersionToApplicationVersion:
   "3.0.2": "0.0.1"
   "3.1.0": "0.1.0"
   "3.1.1": "0.1.0"
+  "3.1.2": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:
@@ -55,3 +56,9 @@ chartValidationLog:
   result: PASS
   tester: bquan-hpe
   date: 2023-05-05
+- chartVersion: 3.2.0
+  csm: 1.5.0
+  environment: 
+  result:
+  tester:
+  date: 

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -56,7 +56,7 @@ chartValidationLog:
   result: PASS
   tester: bquan-hpe
   date: 2023-05-05
-- chartVersion: 3.2.0
+- chartVersion: 3.1.2
   csm: 1.5.0
   environment: dorian (vshasta)
   result: PASS


### PR DESCRIPTION
## Summary and Scope

Have cray-nls chart use cray-nls version 0.10.11.


## Testing

Tested a cray-nls-chart upgrade on Dorian.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

