### PR TITLE
CASM-4352 Remove installation of dependencies using zypper entirely to rely upon the host for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,11 @@ charts/v3.0/cray-iuf/charts/metacontroller-helm-v4.4.0.tgz
 charts/v3.0/cray-iuf/charts/metacontroller-helm-v4.10.3.tgz
 charts/v3.0/cray-iuf/Chart.lock
 charts/v3.0/cray-nls/tmpcharts
+charts/v4.0/cray-nls/charts
+charts/v4.0/cray-nls/Chart.lock
+charts/v4.0/cray-iuf/charts/metacontroller-helm-v4.4.0.tgz
+charts/v4.0/cray-iuf/charts/metacontroller-helm-v4.10.3.tgz
+charts/v4.0/cray-iuf/Chart.lock
+charts/v4.0/cray-nls/tmpcharts
 vendor
 .idea

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # cray-nls-charts
 This deploys cray-nls and argo-workflow
+
+# Versioning
+
+The version numbers to be used must follow the format given in the table below. Note that the format is different for
+CSM 1.4.x releases because this convention is decided after the CSM 1.4.0 release but before the 1.5.0 release, so it was
+not possible to change the convention for a previously released product.
+
+| CSM Version | .version file in cray-nls | Helm chart version in cray-nls-charts |
+|-------------|---------------------------|---------------------------------------|
+| 1.4.x       | 0.(10+x).y                | 2.(10+x).y                            |
+| 1.5.x       | 3.x.y                     | 3.x.y                                 |
+| 1.6.x       | 4.x.y                     | 4.x.y                                 |

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ not possible to change the convention for a previously released product.
 | CSM Version | .version file in cray-nls | Helm chart version in cray-nls-charts |
 |-------------|---------------------------|---------------------------------------|
 | 1.4.x       | 0.(10+x).y                | 2.(10+x).y                            |
-| 1.5.x       | 3.x.y                     | 3.x.y                                 |
+| 1.5.x       | 3.(1+x).y                 | 3.(1+x).y                             |
 | 1.6.x       | 4.x.y                     | 4.x.y                                 |

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ not possible to change the convention for a previously released product.
 | 1.4.x       | 0.(10+x).y                | 2.(10+x).y                            |
 | 1.5.x       | 3.(1+x).y                 | 3.(1+x).y                             |
 | 1.6.x       | 4.x.y                     | 4.x.y                                 |
+
+PLEASE FOLLOW SEMANTIC VERSIONING GUIDELINES FROM CSM VERSION.
+
+This means that:
+1. You should not be updating minor or major versions of cray-nls in a patch update of CSM.
+2. You should not be updating major versions of cray-nls in a minor update of CSM.
+3. An update of dependencies does not change the public interfaces of cray-nls, so need to update minor/major version.

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.0.1  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug5  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug6  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug8  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug9  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug9  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug10  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug3  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug4  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug6  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug7  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug7  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug8  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug10  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug11  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug2  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug4  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug5  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-iuf/Chart.yaml
+++ b/charts/v2.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 2.11.0-debug2  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug3  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug3  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug4  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug8  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug9  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug10  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug6  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.0.1  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug4  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug6  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug7  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug9  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug10  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug7  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug8  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/Chart.yaml
+++ b/charts/v2.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 2.11.0-debug2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 2.11.0-debug3  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug9
+        tag: 0.11.0-debug10
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug5
+        tag: 0.11.0-debug6
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug7
+        tag: 0.11.0-debug8
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug3
+        tag: 0.11.0-debug4
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug8
+        tag: 0.11.0-debug9
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug11
+        tag: 0.11.0
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug2
+        tag: 0.11.0-debug3
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug4
+        tag: 0.11.0-debug5
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug6
+        tag: 0.11.0-debug7
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0-debug10
+        tag: 0.11.0-debug11
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.9
+        tag: 0.11.0
       resources:
         limits:
           cpu: 1

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -210,7 +210,7 @@ argo-workflows:
       registry: artifactory.algol60.net/csm-docker/stable
       # -- Registry to use for the controller
       repository: quay.io/argoproj/argoexec
-      tag: v3.4.5
+      tag: v3.3.6
   server:
     affinity:
       podAntiAffinity:

--- a/charts/v2.0/cray-nls/values.yaml
+++ b/charts/v2.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.11.0
+        tag: 0.11.0-debug2
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.4  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.5  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.4  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.13
+        tag: 0.10.14
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 0.10.14
+        tag: 3.1.5
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -206,7 +206,7 @@ argo-workflows:
       registry: artifactory.algol60.net/csm-docker/stable
       # -- Registry to use for the controller
       repository: quay.io/argoproj/argoexec
-      tag: v3.4.5
+      tag: v3.3.6
   server:
     affinity:
       podAntiAffinity:

--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -1,0 +1,41 @@
+#
+# MIT License
+#
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+apiVersion: v2
+name: "cray-iuf"
+version: 4.0.0  # Also update cray-nls version and cray-nls.compatibility.yaml file
+description: "Kubernetes resources for cray-iuf"
+home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
+sources:
+  - "https://github.com/Cray-HPE/cray-nls-charts"
+dependencies:
+  - name: metacontroller-helm
+    version: "v4.10.3"
+    repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
+maintainers:
+  - name: Platform Engineering
+    url: https://github.com/orgs/Cray-HPE/teams/platform-engineering
+appVersion: "0.1.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-iuf/values.yaml
+++ b/charts/v4.0/cray-iuf/values.yaml
@@ -1,0 +1,48 @@
+#
+# MIT License
+#
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+global:
+  appVersion: 0.1.0
+
+metacontroller-helm:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/metacontrollerio/metacontroller
+    tag: v4.10.3
+  replicas: 2
+  commandArgs:
+    - --zap-log-level=4
+    - --discovery-interval=20s
+    - --cache-flush-interval=30m
+    - --leader-election
+  podDisruptionBudget:
+    minAvailable: 1
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - metacontroller-helm

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -1,0 +1,50 @@
+#
+# MIT License
+#
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+apiVersion: v2
+name: "cray-nls"
+version: 4.0.0  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+description: "Kubernetes resources for cray-nls"
+home: "https://github.com/Cray-HPE/cray-nls-charts"
+sources:
+  - "https://github.com/Cray-HPE/cray-nls-charts"
+dependencies:
+  - name: cray-service
+    version: ~8.2.0
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+    alias: cray-service
+  - name: cray-postgresql
+    version: ^1.0.0
+    repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
+  - name: argo-workflows
+    # TODO: point to Alex argo workflow repo
+    # When his PR is merged
+    version: "0.22.13"
+    repository: https://argoproj.github.io/argo-helm
+maintainers:
+  - name: Platform Engineering
+    url: https://github.com/orgs/Cray-HPE/teams/platform-engineering
+appVersion: "0.1.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-nls/templates/configmap.yaml
+++ b/charts/v4.0/cray-nls/templates/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: worker-rebuild-workflow-files
+data:
+  readme: |
+    Config map to store worker rebuild workflow files    
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: storage-rebuild-workflow-files
+data:
+  readme: |
+    Config map to store storage rebuild workflow files
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iuf-install-workflow-files
+data:
+  readme: |
+    Config map to store iuf install workflow files
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iuf-install-workflow-stages-files
+data:
+  readme: |
+    Config map to store iuf install workflow stages files

--- a/charts/v4.0/cray-nls/templates/metacontrollers.yaml
+++ b/charts/v4.0/cray-nls/templates/metacontrollers.yaml
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# rebuild hooks
+---
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: CompositeController
+metadata:
+  name: nls-hooks
+spec:
+  generateSelector: true
+  parentResource:
+    apiVersion: cray-nls.hpe.com/v1
+    resource: hooks
+  hooks:
+    sync:
+      webhook:
+        url: "http://{{ index .Values "argo-host" }}/apis/nls/v1/ncns/hooks"
+
+---
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: DecoratorController
+metadata:
+  name: iuf-session
+spec:
+  resources:
+    - apiVersion: v1
+      resource: configmaps
+      labelSelector:
+        matchLabels:
+          type: iuf_session
+        matchExpressions:
+          - key: "completed"
+            operator: "DoesNotExist"
+  hooks:
+    sync:
+      webhook:
+        url: "http://{{ index .Values "argo-host" }}/apis/iuf/v1/session/sync"
+        timeout: 30s
+

--- a/charts/v4.0/cray-nls/templates/pdb.yaml
+++ b/charts/v4.0/cray-nls/templates/pdb.yaml
@@ -1,0 +1,34 @@
+{{/*
+MIT License
+
+(C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: pdb-cray-cls
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cray-nls

--- a/charts/v4.0/cray-nls/templates/rbac.yaml
+++ b/charts/v4.0/cray-nls/templates/rbac.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# This cluster role binding allows anyone in the "manager" group to
+# read secrets in any namespace.
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin-for-argo
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:masters
+  - kind: ServiceAccount
+    name: default
+    namespace: argo
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/v4.0/cray-nls/templates/secret.yaml
+++ b/charts/v4.0/cray-nls/templates/secret.yaml
@@ -1,0 +1,34 @@
+#
+# MIT License
+#
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-server-secret
+  annotations:
+    kubernetes.io/service-account.name: cray-nls-argo-workflows-server
+type: kubernetes.io/service-account-token
+
+   
+   

--- a/charts/v4.0/cray-nls/templates/service.yaml
+++ b/charts/v4.0/cray-nls/templates/service.yaml
@@ -1,0 +1,64 @@
+{{/*
+MIT License
+
+(C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-server-internal
+  labels:
+    app.kubernetes.io/name: argo-server-internal
+spec:
+  type: ClusterIP
+  ports:
+    - port: 2746
+      targetPort: 2746
+      protocol: TCP
+  selector:
+    app.kubernetes.io/instance: cray-nls
+    app.kubernetes.io/name: argo-workflows-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflow-controller-metrics
+  annotations:
+    meta.helm.sh/release-name: cray-nls
+  labels:
+    app.kubernetes.io/component: workflow-controller
+    app.kubernetes.io/instance: cray-nls
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/part-of: argo-workflows
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/instance: cray-nls
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/charts/v4.0/cray-nls/templates/virtualservice.yaml
+++ b/charts/v4.0/cray-nls/templates/virtualservice.yaml
@@ -1,0 +1,69 @@
+
+   
+#
+# MIT License
+#
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{- if .Values.ingress.enabled -}}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: cray-argo
+spec:
+  gateways:
+  - services/services-gateway
+  - services/customer-admin-gateway
+  hosts:
+  - argo.{{ .Values.externalHostname }}
+  http:
+  - match:
+    - authority:
+        exact: argo.{{ .Values.externalHostname }}
+    route:
+    - destination:
+        host: cray-nls-argo-workflows-server.argo.svc.cluster.local
+        port:
+          number: 2746
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: cray-iuf
+spec:
+  gateways:
+  - services/services-gateway
+  - services/customer-admin-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+      - uri:
+          prefix: /apis/iuf
+    rewrite:
+      uri: /apis/iuf
+    route:
+      - destination:
+          host: cray-nls
+          port:
+            number: 80
+{{- end -}}

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -1,0 +1,275 @@
+#
+# MIT License
+#
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+global:
+  appVersion: 0.1.0
+
+argo-host: cray-nls.argo.svc:80
+
+ingress:
+  enabled: true
+
+externalHostname: argo.local
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-nls"
+  fullnameOverride: "cray-nls"
+  priorityClassName: csm-high-priority-service
+  replicaCount: 3
+  volumes:
+    - name: worker-rebuild-workflow-files
+      configMap:
+        name: worker-rebuild-workflow-files
+    - name: storage-rebuild-workflow-files
+      configMap:
+        name: storage-rebuild-workflow-files
+    - name: iuf-install-workflow-files
+      configMap:
+        name: iuf-install-workflow-files
+    - name: iuf-install-workflow-stages-files
+      configMap:
+        name: iuf-install-workflow-stages-files
+    - name: iuf
+      hostPath:
+        path: /etc/cray/upgrade/csm
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdCluster:
+    enabled: false
+    tls:
+      enabled: false
+  initContainers:
+    wait-for-argo-server:
+      name: "wait-for-argo-server"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl
+        tag: 7.80.0
+      pullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://argo-server-internal.argo.svc.cluster.local:2746)" != "200" ]]; do echo "Waiting for argo server"; sleep 3;  done; echo "Argo Server is UP";
+
+  containers:
+    cray-nls:
+      volumeMounts:
+        - name: worker-rebuild-workflow-files
+          readOnly: true
+          mountPath: /workflows/worker/ncn
+        - name: storage-rebuild-workflow-files
+          readOnly: true
+          mountPath: /workflows/storage/ncn
+        - name: iuf-install-workflow-files
+          readOnly: true
+          mountPath: /workflows/iuf
+        - name: iuf-install-workflow-stages-files
+          readOnly: true
+          mountPath: /workflows/iuf/stages
+        - name: iuf
+          mountPath: /etc/cray/upgrade/csm
+      name: "cray-nls"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-nls
+        tag: 4.0.0
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 256Mi
+      env:
+        - name: ARGO_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: argo-server-secret
+              key: token
+        - name: SERVER_PORT
+          value: "3000"
+        - name: ENV
+          value: production
+        - name: GIN_MODE
+          value: release
+        - name: ARGO_SERVER_URL
+          value: argo-server-internal.argo.svc.cluster.local:2746
+        - name: API_GATEWAY_URL
+          value: https://api-gw-service-nmn.local
+        - name: WORKER_REBUILD_WORKFLOW_FILES
+          value: "/workflows/worker"
+        - name: STORAGE_REBUILD_WORKFLOW_FILES
+          value: "/workflows/storage"
+        - name: IUF_INSTALL_WORKFLOW_FILES
+          value: "/workflows/iuf"
+        - name: MEDIA_DIR_BASE
+          value: "/etc/cray/upgrade/csm"
+        - name: POSTGRES_HOST
+          value: cray-nls-postgres
+        - name: POSTGRES_PORT
+          value: "5432"
+      ports:
+        - name: http
+          containerPort: 3000
+      livenessProbe:
+        httpGet:
+          port: 3000
+          path: /apis/nls/v1/liveness
+        initialDelaySeconds: 5
+        periodSeconds: 3
+      readinessProbe:
+        httpGet:
+          port: 3000
+          path: /apis/nls/v1/readiness
+        initialDelaySeconds: 20
+        periodSeconds: 60
+  ingress:
+    gateways:
+      - "services/services-gateway"
+      - "services/customer-admin-gateway"
+    enabled: true
+    prefix: /apis/nls
+    uri: /apis/nls
+
+# Database cluster sub-chart configuration
+cray-postgresql:
+  nameOverride: cray-nls
+  sqlCluster:
+    enabled: true
+    tls:
+      enabled: false
+    waitForItJob: false
+    enableLogicalBackup: true
+    # Once per day at 11:10 pm
+    logicalBackupSchedule: "10 23 * * *"
+    volumeSize: 2Gi
+    users:
+      argouser: []
+    databases:
+      argo: argouser
+
+# argo workflow
+argo-workflows:
+  useDefaultArtifactRepo: true
+  useStaticCredentials: true
+  artifactRepository:
+    archiveLogs: true
+    s3:
+      bucket: config-data
+      keyFormat: "{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}"
+      endpoint: rgw-vip.local
+      insecure: true
+      accessKeySecret:
+        name: config-data-s3-credentials
+        key: access_key
+      secretKeySecret:
+        name: config-data-s3-credentials
+        key: secret_key
+  workflow:
+    workflowNamespaces:
+      - argo
+  executor:
+    image:
+      # -- Registry to use for the controller
+      registry: artifactory.algol60.net/csm-docker/stable
+      # -- Registry to use for the controller
+      repository: quay.io/argoproj/argoexec
+      tag: v3.4.5
+  server:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - argo-workflows-server
+            topologyKey: kubernetes.io/hostname
+    replicas: 3
+    image:
+      # -- Registry to use for the controller
+      registry: artifactory.algol60.net/csm-docker/stable
+      # -- Registry to use for the controller
+      repository: quay.io/argoproj/argocli
+      tag: v3.4.5
+    pdb:
+      enabled: true
+      minAvailable: 1
+    extraArgs:
+      - --auth-mode=server
+      - --namespaced
+  controller:
+    image:
+      # -- Registry to use for the controller
+      registry: artifactory.algol60.net/csm-docker/stable
+      # -- Registry to use for the controller
+      repository: quay.io/argoproj/workflow-controller
+      # -- Overrides the image tag whose default is the chart appVersion.
+      tag: v3.4.5
+    replicas: 2
+    pdb:
+      enabled: true
+      minAvailable: 1
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - argo-workflows-workflow-controller
+    persistence:
+      postgresql:
+        host: cray-nls-postgres
+        port: 5432
+        database: argo
+        tableName: argo_workflows
+        # the database secrets must be in the same namespace of the controller
+        userNameSecret:
+          name: argouser.cray-nls-postgres.credentials
+          key: username
+        passwordSecret:
+          name: argouser.cray-nls-postgres.credentials
+          key: password

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -206,7 +206,7 @@ argo-workflows:
       registry: artifactory.algol60.net/csm-docker/stable
       # -- Registry to use for the controller
       repository: quay.io/argoproj/argoexec
-      tag: v3.4.5
+      tag: v3.3.6
   server:
     affinity:
       podAntiAffinity:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -20,6 +20,7 @@ chartVersionToApplicationVersion:
   "3.1.2": "0.1.0"
   "3.1.3": "0.1.0"
   "3.1.4": "0.1.0"
+  "3.1.5": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -13,6 +13,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "0.0.1"
   "2.0.1": "0.0.1"
+  "2.11.0": "0.0.1"
   "3.0.0": "0.0.1"
   "3.0.1": "0.0.1"
   "3.0.2": "0.0.1"

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -2,8 +2,9 @@
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
   # Chart version: CSM version
-  ">=2.0.0": "~1.4.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.4.0 <= x.y.z < 1.5.0
-  ">=3.0.0": ">=1.5.0" # Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  ">=2.0.0": "~1.4.0" # Chart Version: 2.0.0 <= x.y.z < 3.0.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
+  ">=3.0.0": "~1.5.0" # Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  ">=4.0.0": ">=1.6.0" # Chart Version: 4.0.0 <= x.y.z < 5.0.0, CSM Version: 1.6.0 <= x.y.z
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -21,6 +22,7 @@ chartVersionToApplicationVersion:
   "3.1.3": "0.1.0"
   "3.1.4": "0.1.0"
   "3.1.5": "0.1.0"
+  "4.0.0": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Remove installation of dependencies using zypper entirely to rely upon the host for dependencies.

We are removing these because the dependencies in the host are more up-to-date, as opposed to the embedding them within this container which doesn't get updated often.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-4352](https://jira-pro.it.hpe.com:8443/browse/CASM-4352)
* Merged code PR: https://github.com/Cray-HPE/iuf-containers/pull/18

## Testing

### Tested on:

Drax

### Test description:

Removed internally embedded dependencies from the image, volume mounted the host /usr/bin directory, appended the $PATH inside the container, and checked if the dependencies are accessible.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

