### PR TITLE
CASMPET-6732 bump cray-nls version

### DIFF
--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.8  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.9  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.8  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.9  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.8
+        tag: 3.1.9
       resources:
         limits:
           cpu: 1

--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.1  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.3  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.3  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.0.2
+        tag: 4.0.3
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -29,9 +29,11 @@ chartVersionToApplicationVersion:
   "3.1.6": "0.1.0"
   "3.1.7": "0.1.0"
   "3.1.8": "0.1.0"
+  "3.1.9": "0.1.0"
   "4.0.0": "0.1.0"
   "4.0.1": "0.1.0"
   "4.0.2": "0.1.0"
+  "4.0.3": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -78,3 +78,9 @@ chartValidationLog:
   result: PASS
   tester: leliasen-hpe
   date: 2023-06-01
+- chartVersion: 4.0.3
+  csm: 1.6.0
+  environment: dorian (vshasta)
+  result: PASS
+  tester: leliasen-hpe
+  date: 2023-08-24


### PR DESCRIPTION
## Summary and Scope

Bump cray-nls version to 4.0.3 for CSM 1.6 and to 3.1.9 for CSM 1.5.

This changes the cray-nls backend to now look for specific workflows for NCN type (worker, storage, master node) instead of just looking for a workflow called `management-nodes-rollout`.

## Issues and Related PRs


* Resolves CASMPET-6732

## Testing


### Tested on:

  * Dorian

### Test description:

Tested upgrading to the new cray-nls helm chart and running a workflow which previously would've caused an error.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

