### PR TITLE
CASMTRIAGE-5951 bump cray-nls chart versions to 3.1.10 and 4.0.4

### DIFF
--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.9  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.10  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.9  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.10  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.9
+        tag: 3.1.10
       resources:
         limits:
           cpu: 1

--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.3  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.4  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.3  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.4  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.0.3
+        tag: 4.0.4
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -86,3 +86,9 @@ chartValidationLog:
   result: PASS
   tester: leliasen-hpe
   date: 2023-08-24
+- chartVersion: 4.0.4
+  csm: 1.6.0
+  environment: dorian (vshasta)
+  result: PASS
+  tester: leliasen-hpe
+  date: 2023-08-31

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -30,10 +30,12 @@ chartVersionToApplicationVersion:
   "3.1.7": "0.1.0"
   "3.1.8": "0.1.0"
   "3.1.9": "0.1.0"
+  "3.1.10": "0.1.0"
   "4.0.0": "0.1.0"
   "4.0.1": "0.1.0"
   "4.0.2": "0.1.0"
   "4.0.3": "0.1.0"
+  "4.0.4": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

These changes are for having a graceful error when no --limit-management-rollout parameter is supplied to IUF during management-nodes-rollout

## Issues and Related PRs


* Resolves [CASMTRIAGE-5951](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5951)

## Testing

Tested upgrade on Dorain. (CSM 1.6 vShasta)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

