### PR TITLE
CASM-4557 bumb cray-nls image version to 4.0.5

### DIFF
--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.4  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.5  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.4  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.0.4
+        tag: 4.0.5
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -36,6 +36,7 @@ chartVersionToApplicationVersion:
   "4.0.2": "0.1.0"
   "4.0.3": "0.1.0"
   "4.0.4": "0.1.0"
+  "4.0.5": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:
@@ -92,3 +93,9 @@ chartValidationLog:
   result: PASS
   tester: leliasen-hpe
   date: 2023-08-31
+- chartVersion: 4.0.5
+  csm: 1.6.0
+  environment: mug
+  result: PASS
+  tester: leliasen-hpe
+  date: 2023-11-02


### PR DESCRIPTION
## Summary and Scope

Bump cray-nls chart version to 4.0.5.

## Issues and Related PRs

* Resolves [CASM-4557](https://jira-pro.it.hpe.com:8443/browse/CASM-4557)

## Testing

Deployed successfully on mug. 


## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

