### PR TITLE
CASMTRIAGE-6206

### DIFF
--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug1  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug10  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug11  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug12  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug8  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug9  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug7  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug2  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug7  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug8  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug5  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug1  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug2  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug9  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug10  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug5  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug6  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug6  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.10  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11-debug11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug12  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug8  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug9  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug12  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug6  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug7  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug8  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug6  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.10  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug12  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug7  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug1  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug1  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug9  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug10  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug10  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11-debug11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11-debug2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug7
+        tag: 3.1.11-debug8
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.10
+        tag: 3.1.11
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11
+        tag: 3.1.11-debug5
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug9
+        tag: 3.1.11-debug10
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11
+        tag: 3.1.11-debug6
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug12
+        tag: 3.1.11
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug8
+        tag: 3.1.11-debug9
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug5
+        tag: 3.1.11
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug6
+        tag: 3.1.11
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11
+        tag: 3.1.11-debug7
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug1
+        tag: 3.1.11-debug2
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug10
+        tag: 3.1.11-debug11
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11
+        tag: 3.1.11-debug1
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug11
+        tag: 3.1.11-debug12
       resources:
         limits:
           cpu: 1

--- a/charts/v3.0/cray-nls/values.yaml
+++ b/charts/v3.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 3.1.11-debug2
+        tag: 3.1.11
       resources:
         limits:
           cpu: 1

--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.5  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.6  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.6  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.0.5
+        tag: 4.0.6
       resources:
         limits:
           cpu: 1


### PR DESCRIPTION
## Summary and Scope

### Problem

Currently, whenever we install products with IUF, irrespective of how many products we are installing, there is always a single Argo workflow for each stage per IUF run.

The problem with this approach is when the number of products being installed is arbitrarily large. In that case, the Argo workflow becomes huge at runtime, and cross the resource limits of the underlying etcd resource (1mb) that Argo uses to store the workflows.

This means that during the running of this large Argo workflow, an error is thrown by etcd, which Argo does not react well to -- it continues to think the workflow is in progress and gets hung.

### Solution

The 1mb limit is a hard limit and there is no way to increase it either on a per-resource basis or on a global basis.

This means that we need to support breaking up the stage into multiple workflows when a single workflow exceeds the Argo resource size limits.

### When to break up a stage into multiple workflows

Unfortunately, since the metadata (inputs, outputs) is also arbitrary, we cannot reasonably predict the size of the instantiated workflow at runtime upon submission of the Argo workflow. 

However, what we can do is know empirically what has worked. The stage that breaks is deliver-product, as it has the most number of operations per product (9 operations). Typically, the number of products that have worked well with deliver-product stage is around 16. Rounding up, we are going to assume that if a workflow input parameters exceeds 150 total operations (products * operations per product), we are going to split up the workflow into multiple partial workflows

### Execution semantics

As per the last section, when we have determined that a stage within a single session needs to be split up into multiple workflows (henceforth known as `partial workflows`), we will need to execute the partial workflows. There are two ways of executing the partial workflows:

1. Execute them sequentially
2. Execute them in parallel

Executing the workflows in parallel may actually overload the system. Recall that, initially when developing IUF, we had to artificially limit the number of tasks that can be run in parallel in a single workflow because the system could not take on running so many containers at once.

Thus, executing sequentially will be the option chosen. This will also allow us to not make any changes to the IUF-cli, which if we had executed in parallel, would have caused a lot of confusion in terms of numbering the tasks in the logs (identical index numbers for tasks across parallel partial workflows)

### Scenarios to test

We also have to keep in mind the following set of scenarios still work:

1. The success of a split-up-stage in a single session = success of all partial workflows of that stage in a single session
2. The failure of a split-up-stage in a single session = failure of at least one partial workflow of that stage in a single session.
3. `iuf-cli` still works in terms of logging and exiting
4. Abort, retry, resume primitives all work with iuf-cli
5. Original scenarios with number of products that can be handled in a single workflow still continue to work as before.

### Debuggability

We are going to attach a two types of labels to each workflow going forward:

1. `partial_workflow: "true"` -- add to only partial workflows. Non-partial workflows will not have this label.
2. `product_$productName: $ver` -- added to all workflows. This will allow you to look up, in the Argo UI for e.g., what workflows were processing a particular version of a particular product.

### Race condition

There was a race condition that existed prior to this PR which only surfaced rarely on systems, whereby multiple workflows were started with the identical input parameters and products, mostly happening with the `deliver-product` stage. After changes to this PR were introduced, this race condition was no longer rare and happened every time.

It turned out that the k8s operator was timing out when synchronizing the session resource if the workflow generation took longer than 30s, at which point the k8s operator would make another call to the IUF backend. However, there were no mutexes around the code that was creating a workflow for a stage for the first time, hence there were multiple duplicate workflows created.

This PR introduces a mutex on that critical section so that this race condition does not occur anymore. However, the mutex is implemented in a best-effort way -- using etcd resources which are themselves eventually consistent. Unfortunately, we do not have the necessary platform dependencies yet to do proper distributed locking (e.g. locks built on top of redis). However, in practice this poor-man's mutex has worked well and is saving us from introducing more dependencies and hence more regressions.

### 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6206](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6206)

## Testing

### Tested on:

  * `fanta`
  * Local development environment (unit tests)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Ran IUF

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

