### PR TITLE
CASMPET-6869: rebuild to pick up cray-postgtesql-1.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ tmp
 gin-bin
 coverage.txt
 .vscode
+.DS_Store
+charts/.DS_Store
 charts/v1.0
 charts/v2.0/cray-nls/charts
 charts/v2.0/cray-nls/Chart.lock
@@ -13,11 +15,14 @@ charts/v2.0/cray-iuf/charts/metacontroller-helm-v4.4.0.tgz
 charts/v2.0/cray-iuf/charts/metacontroller-helm-v4.10.3.tgz
 charts/v2.0/cray-iuf/Chart.lock
 charts/v2.0/cray-nls/tmpcharts
+charts/v3.0/.DS_Store
 charts/v3.0/cray-nls/charts
 charts/v3.0/cray-nls/Chart.lock
 charts/v3.0/cray-iuf/charts/metacontroller-helm-v4.4.0.tgz
 charts/v3.0/cray-iuf/charts/metacontroller-helm-v4.10.3.tgz
 charts/v3.0/cray-iuf/Chart.lock
+charts/v3.0/cray-iuf/.DS_Store
+charts/v3.0/cray-iuf/charts/
 charts/v3.0/cray-nls/tmpcharts
 charts/v4.0/cray-nls/charts
 charts/v4.0/cray-nls/Chart.lock

--- a/charts/v3.0/cray-iuf/Chart.yaml
+++ b/charts/v3.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 3.1.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 3.1.12  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v3.0/cray-nls/Chart.yaml
+++ b/charts/v3.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 3.1.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 3.1.12  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.6  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.7  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.6  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.7  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -31,12 +31,14 @@ chartVersionToApplicationVersion:
   "3.1.8": "0.1.0"
   "3.1.9": "0.1.0"
   "3.1.10": "0.1.0"
+  "3.1.12": "0.1.0"
   "4.0.0": "0.1.0"
   "4.0.1": "0.1.0"
   "4.0.2": "0.1.0"
   "4.0.3": "0.1.0"
   "4.0.4": "0.1.0"
   "4.0.5": "0.1.0"
+  "4.0.7": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Rebuild cray-nls charts to pick up a bug fix from cray-postgtesql-1.0.4 for CSM 1.5 and CSM 1.6.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6869](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6869)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `fanta`
  * Local development environment
  * Virtual Shasta

### Test description:

Manually applied the replication bug fix and verified that the replication issue was resolved.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

