### PR TITLE
CASM-4606: Execution of management-nodes-rollout on m002

### DIFF
--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.9  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.10  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.9  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.10  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -104,7 +104,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.0.9
+        tag: 4.0.10
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -41,6 +41,7 @@ chartVersionToApplicationVersion:
   "4.0.5": "0.1.0"
   "4.0.7": "0.1.0"
   "4.0.9": "0.1.0"
+  "4.0.10": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

cray-nls version update from 4.0.9 to 4.0.10

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASM-4606
* https://github.com/Cray-HPE/cray-nls/pull/211

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

