### PR TITLE
CASMPET-7061 Update cray-service chart version use by cray-nls

### DIFF
--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -2,7 +2,7 @@ name: Build and Publish Helm charts
 on: [push, workflow_dispatch]
 jobs:
   build_and_release:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v3
     with:
       artifactory-component: cray-nls
       target-branch: main

--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.11  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.12  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,14 +24,14 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.11  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.12  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:
   - "https://github.com/Cray-HPE/cray-nls-charts"
 dependencies:
   - name: cray-service
-    version: ~8.2.0
+    version: ~10.0.5
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
     alias: cray-service
   - name: cray-postgresql

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -43,6 +43,7 @@ chartVersionToApplicationVersion:
   "4.0.9": "0.1.0"
   "4.0.10": "0.1.0"
   "4.0.11": "0.1.0"
+  "4.0.12": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Cray-nls chart picked up the latest cray-service chart. This is neccessary because the previous version the cray-service chart used has a cert-manager API that is removed in CSM 1.6. 

## Testing

I tested an install and an upgrade of the cray-nls chart on Beau.

## Risks and Mitigations

Low risk. This is only going into CSM 1.6.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

