### PR TITLE
CASMPET-7078 update cray-nls-chart to use control-plane label instead of master for k8s 1.24

### DIFF
--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.12  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.13  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.12  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.13  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -57,12 +57,15 @@ cray-service:
     - key: "node-role.kubernetes.io/master"
       operator: "Exists"
       effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node-role.kubernetes.io/master
+              - key: node-role.kubernetes.io/control-plane
                 operator: Exists
   strategy:
     rollingUpdate:
@@ -104,7 +107,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.0.11
+        tag: 4.0.12
       resources:
         limits:
           cpu: 1
@@ -249,7 +252,7 @@ argo-workflows:
           - weight: 50
             preference:
               matchExpressions:
-                - key: node-role.kubernetes.io/master
+                - key: node-role.kubernetes.io/control-plane
                   operator: Exists
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -44,6 +44,7 @@ chartVersionToApplicationVersion:
   "4.0.10": "0.1.0"
   "4.0.11": "0.1.0"
   "4.0.12": "0.1.0"
+  "4.0.13": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

The cray-nls and cray-iuf charts needed to updated to add the `node-role.kubernetes.io/control-plane` toleration and to change the affinity label from `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane`. This is necessary for k8s 1.24 in CSM 1.6.

## Issues and Related PRs

* Relates to [CASMPET-7078](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7078)

## Testing

Deployed charts on Beau (CSM 1.6, K8s 1.22). Argo workflow ran successfully.


## Risks and Mitigations

Low risk change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

