### PR TITLE
CASMPET-7219 bump cray-service chart version to 11.0.0

### DIFF
--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.14  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.0.15  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,14 +24,14 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.14  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.0.15  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:
   - "https://github.com/Cray-HPE/cray-nls-charts"
 dependencies:
   - name: cray-service
-    version: ~10.0.5
+    version: ~11.0.0
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
     alias: cray-service
   - name: cray-postgresql

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -46,6 +46,7 @@ chartVersionToApplicationVersion:
   "4.0.12": "0.1.0"
   "4.0.13": "0.1.0"
   "4.0.14": "0.1.0"
+  "4.0.15": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

The cray-service chart version that should be used with k8s 1.24 in CSM 1.6 is 11.0.0. This PR bump the cray-service chart version in cray-nls.

## Issues and Related PRs

* Relates to [CASMPET-7219](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7219)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

