### PR TITLE
CASMTRIAGE-7425-csm-1.6.1 create cray-nls.hpe.com_hooks crd via cray-nls chart

### DIFF
--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.0.15  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.1.0  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.0.15  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.1.0  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/crds/cray-nls.hpe.com_hooks.yaml
+++ b/charts/v4.0/cray-nls/crds/cray-nls.hpe.com_hooks.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: hooks.cray-nls.hpe.com
+spec:
+  group: cray-nls.hpe.com
+  names:
+    kind: Hook
+    listKind: HookList
+    plural: hooks
+    singular: hook
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Hook
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              scriptContent:
+                type: string
+              templateRefName:
+                type: string
+            required:
+            - scriptContent
+            - templateRefName
+            type: object
+          status:
+            properties:
+              observedGeneration:
+                type: integer
+              phase:
+                type: string
+            required:
+            - observedGeneration
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/v4.0/cray-nls/values.yaml
+++ b/charts/v4.0/cray-nls/values.yaml
@@ -107,7 +107,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.0.13
+        tag: 4.1.0
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -47,6 +47,7 @@ chartVersionToApplicationVersion:
   "4.0.13": "0.1.0"
   "4.0.14": "0.1.0"
   "4.0.15": "0.1.0"
+  "4.1.0": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

The cray-nls.hpe.com_hooks crd has been created by the cray-nls pods. This has caused a minor race condition that causes one pod to restart right after deployment. This creates an issue when upgrading cray-nls with IUF or when moving cray-nls pods from one node to another while IUF is running.

The PR correctly creates this CRD by the chart. This stops the race condition and causes no pods to need to restart and should resolve issues seen with the IUF CLI.

The related cray-nls PR is: https://github.com/Cray-HPE/cray-nls/pull/216

## Issues and Related PRs

* Resolves [CASMTRIAGE-7425](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7425)
* Relates to [CASMTRIAGE-7402](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7402).

## Testing

### Tested on:

  * Tested fresh installs and upgrades on Beau (Vshasta2)

## Risks and Mitigations

Low risk change

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

