### PR TITLE
CASMPET-7247: Use policy/v1 instead of policy/v1beta1 in cray-nls chart

### DIFF
--- a/charts/v4.0/cray-iuf/Chart.yaml
+++ b/charts/v4.0/cray-iuf/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2023, 2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 4.1.2  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 4.1.3  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v4.0/cray-nls/Chart.yaml
+++ b/charts/v4.0/cray-nls/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2023, 2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 4.1.2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 4.1.3  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v4.0/cray-nls/templates/pdb.yaml
+++ b/charts/v4.0/cray-nls/templates/pdb.yaml
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */}}
 
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pdb-cray-cls

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -50,6 +50,7 @@ chartVersionToApplicationVersion:
   "4.1.0": "0.1.0"
   "4.1.1": "0.1.0"
   "4.1.2": "0.1.0"
+  "4.1.3": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

In preparation for the Kubernetes upgrade to v1.32 in CSM v1.7, apiVersion `policy/v1beta1` needs to change to `policy/v1` since `policy/v1beta1` does not exist in K8s v1.32.  apiVersion `policy/v1` does exist in K8s v1.24, so works in CSM v1.6.

## Issues and Related PRs

* Resolves [CASMPET-7247](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7247)

## Testing

Updated chart on beau with no issues.

```
pit:~/studenym/cray-nls # helm list -n argo
NAME    	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                                	APP VERSION
cray-iuf	argo     	1       	2025-01-13 14:35:49.713223358 +0000 UTC	deployed	cray-iuf-4.1.2                       	0.1.0
cray-nls	argo     	4       	2025-01-13 19:35:03.130615296 +0000 UTC	deployed	cray-nls-4.1.3-20250113162125+c90978f	0.1.0
pit:~/studenym/cray-nls # helm history -n argo cray-nls
REVISION	UPDATED                 	STATUS    	CHART                                	APP VERSION	DESCRIPTION
1       	Mon Jan 13 14:35:52 2025	superseded	cray-nls-4.1.2                       	0.1.0      	Install complete
2       	Mon Jan 13 19:26:24 2025	superseded	cray-nls-4.1.3-20250113162125+c90978f	0.1.0      	Upgrade complete
3       	Mon Jan 13 19:29:27 2025	superseded	cray-nls-4.1.2                       	0.1.0      	Rollback to 1
4       	Mon Jan 13 19:35:03 2025	deployed  	cray-nls-4.1.3-20250113162125+c90978f	0.1.0      	Upgrade complete
pit:~/studenym/cray-nls #
```

Rolled back to `cray-nls-4.1.2` where you see the warning about `policy/v1beta1` being unavailable in K8s v1.25+.

```
pit:~/studenym/cray-nls # helm rollback -n argo cray-nls 1
W0113 20:32:03.905056   29810 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0113 20:32:03.908804   29810 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0113 20:32:03.912928   29810 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
Rollback was a success! Happy Helming!
pit:~/studenym/cray-nls #
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

