### PR TITLE
CASMINST-6734: SW_ADMIN_PASSWORD variable is not required to be set for tests anymore

### DIFF
--- a/charts/v5.0/cray-iuf/Chart.yaml
+++ b/charts/v5.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 5.0.0  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 5.0.1  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v5.0/cray-nls/Chart.yaml
+++ b/charts/v5.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 5.0.0  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 5.0.1  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v5.0/cray-nls/values.yaml
+++ b/charts/v5.0/cray-nls/values.yaml
@@ -107,7 +107,7 @@ cray-service:
       name: "cray-nls"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-nls
-        tag: 4.1.2
+        tag: 4.2.0
       resources:
         limits:
           cpu: 1

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -115,3 +115,9 @@ chartValidationLog:
   result: PASS
   tester: leliasen-hpe
   date: 2023-11-02
+- chartVersion: 5.0.1
+  csm: 1.7.0
+  environment: wasp
+  result: PASS
+  tester: Srinivas-Anand-HPE
+  date: 2025-03-17


### PR DESCRIPTION

## Summary and Scope

cray-nls version updated from 4.12 to 4.2.0. Updating the chart versions as well.


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._


### Test description:

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
cray-nls image compatible with >1.7.0 docs-csm

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

