### PR TITLE
CASMPET-7522 update cray-services to version 12.0.0 and cray-postgresql to 2.0.0

### DIFF
--- a/charts/v5.0/cray-iuf/Chart.yaml
+++ b/charts/v5.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 5.0.1  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 5.1.0  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v5.0/cray-nls/Chart.yaml
+++ b/charts/v5.0/cray-nls/Chart.yaml
@@ -24,18 +24,18 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 5.0.1  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 5.0.2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:
   - "https://github.com/Cray-HPE/cray-nls-charts"
 dependencies:
   - name: cray-service
-    version: ~11.0.0
+    version: ~12.0.0
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
     alias: cray-service
   - name: cray-postgresql
-    version: ^1.0.0
+    version: ~2.0.0
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
   - name: argo-workflows
     # TODO: point to Alex argo workflow repo

--- a/charts/v5.0/cray-nls/Chart.yaml
+++ b/charts/v5.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 5.0.2  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 5.1.0  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -53,6 +53,7 @@ chartVersionToApplicationVersion:
   "4.1.2": "0.1.0"
   "4.1.3": "0.1.0"
   "5.0.0": "0.1.0"
+  "5.0.2": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -53,7 +53,7 @@ chartVersionToApplicationVersion:
   "4.1.2": "0.1.0"
   "4.1.3": "0.1.0"
   "5.0.0": "0.1.0"
-  "5.0.2": "0.1.0"
+  "5.1.0": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Pick up new postgresql version for CSM 1.7.
Now this uses cray-postgresql chart: 2.0.0 and cray-service chart: 12.0.0.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7522](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7522)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Beau

### Test description:

Tested chart upgrade and downgrade.
(The main postgres upgrade is done previously via the postgres operator. This is a minor change.)

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

