### PR TITLE
CASMSEC-591: Updates argoexec image to v3.4.5

### DIFF
--- a/charts/v5.0/cray-iuf/Chart.yaml
+++ b/charts/v5.0/cray-iuf/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-iuf"
-version: 5.1.4  # Also update cray-nls version and cray-nls.compatibility.yaml file
+version: 5.1.5  # Also update cray-nls version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-iuf"
 home: "https://github.com/Cray-HPE/cray-nls-charts/charts"
 sources:

--- a/charts/v5.0/cray-nls/Chart.yaml
+++ b/charts/v5.0/cray-nls/Chart.yaml
@@ -24,7 +24,7 @@
 
 apiVersion: v2
 name: "cray-nls"
-version: 5.1.4  # Also update cray-iuf version and cray-nls.compatibility.yaml file
+version: 5.1.5  # Also update cray-iuf version and cray-nls.compatibility.yaml file
 description: "Kubernetes resources for cray-nls"
 home: "https://github.com/Cray-HPE/cray-nls-charts"
 sources:

--- a/charts/v5.0/cray-nls/values.yaml
+++ b/charts/v5.0/cray-nls/values.yaml
@@ -209,7 +209,7 @@ argo-workflows:
       registry: artifactory.algol60.net/csm-docker/stable
       # -- Registry to use for the controller
       repository: quay.io/argoproj/argoexec
-      tag: v3.3.6
+      tag: v3.4.5
   server:
     affinity:
       podAntiAffinity:

--- a/cray-nls.compatibility.yaml
+++ b/cray-nls.compatibility.yaml
@@ -58,6 +58,7 @@ chartVersionToApplicationVersion:
   "5.1.2": "0.1.0"
   "5.1.3": "0.1.0"
   "5.1.4": "0.1.0"
+  "5.1.5": "0.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:
@@ -156,3 +157,9 @@ chartValidationLog:
   result: PASS
   tester: Pankhuri-Rajesh
   date: 2025-11-27
+- chartVersion: 5.1.5
+  csm: 1.7.1
+  environment: fanta
+  result: PASS
+  tester: arka-pramanik-hpe
+  date: 2025-12-02


### PR DESCRIPTION
## Summary and Scope

Upgrade Argoexec to v3.4.5 to fix CVEs .

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMSEC-591](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-591)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `bertrand`
  * `fanta`
  * Virtual Shasta

### Test description:

Deployed new cray-nls & cray-iuf charts using v3.4.5 argo images, and made sure that argo server, workflow controller and cray-nls pods are up and running as expected.

```console
(csm-testing-python-venv) ncn-m001:~/arka # loftsman ship --charts-path ./ --manifest-path sysmgmt-cust.yaml 
2025-12-02T08:40:17Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2025-12-02T08:40:17Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~
  
2025-12-02T08:40:17Z INF Ensuring that the loftsman namespace exists command=ship
2025-12-02T08:40:17Z INF Loftsman will use the packaged charts at ./ as the Helm install source command=ship
2025-12-02T08:40:17Z INF Running a release for the provided manifest at sysmgmt-cust.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-nls v5.1.5
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2025-12-02T08:40:17Z INF Found value overrides for chart, applying: 
externalHostname: cmn.fanta.hpc.amslabs.hpecorp.net
 chart=cray-nls command=ship namespace=argo version=5.1.5
2025-12-02T08:40:17Z INF Running helm install/upgrade with arguments: upgrade --install cray-nls cray-nls-5.1.5.tgz --namespace argo --create-namespace --set global.chart.name=cray-nls --set global.chart.version=5.1.5 -f /tmp/loftsman-1764664817/cray-nls-values.yaml chart=cray-nls command=ship namespace=argo version=5.1.5
2025-12-02T08:40:24Z INF Release "cray-nls" has been upgraded. Happy Helming!
NAME: cray-nls
LAST DEPLOYED: Tue Dec  2 08:40:17 2025
NAMESPACE: argo
STATUS: deployed
REVISION: 3
TEST SUITE: None
 chart=cray-nls command=ship namespace=argo version=5.1.5
2025-12-02T08:40:24Z INF Ship status: success. Recording status, manifest to configmap loftsman-sysmgmt in namespace loftsman command=ship
2025-12-02T08:40:24Z INF Recording log data to configmap loftsman-sysmgmt-ship-log in namespace loftsman command=ship

(csm-testing-python-venv) ncn-m001:~/arka # export GOSS_BASE=/opt/cray/tests/install/ncn
(csm-testing-python-venv) ncn-m001:~/arka # goss -g /opt/cray/tests/install/ncn/tests/goss-iuf-activity-apis.yaml --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
.

Total Duration: 57.878s
Count: 1, Failed: 0, Skipped: 0

ncn-m001:~ # iuf -a test-arka-021225 -m /etc/cray/upgrade/csm/iuf-blr run -r process-media
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/test-arka-021225/log/20251202110058
INFO [ACTIVITY: test-arka-021225                               ] BEG Install started at 2025-12-02 11:00:58.997601
INFO Neither --recipe-vars nor --bootprep-config-dir were specified, so
product_vars.yaml will be pulled from the branch
cray/hpc-csm-software-recipe/25.1.0-alpha2 of the hpc-csm-software-recipe git
repo.
INFO [IUF SESSION: test-arka-021225-fqn7f                      ] BEG Started at 2025-12-02 11:01:06.485498
INFO [STAGE: process-media                                     ] BEG Argo workflow: test-arka-021225-fqn7f-process-media-6l52q
INFO [extract-release-distributions                            ] BEG extract-release-distributions
INFO [extract-release-distributions                            ] BEG start-operation
INFO [extract-release-distributions                            ] END start-operation [Succeeded]
INFO [extract-release-distributions                            ] BEG list-tar-files
INFO [extract-release-distributions                            ] END list-tar-files [Succeeded]
INFO [extract-tar-files                                        ] BEG extract-tar-files
INFO [extract-tar-files(0:sma-1.11.5.tar.gz)                   ] BEG extract-tar-files(0:sma-1.11.5.tar.gz)

INFO [extract-tar-files                                        ] END extract-tar-files [Succeeded]
INFO [extract-tar-files(0:sma-1.11.5.tar.gz)                   ] END extract-tar-files(0:sma-1.11.5.tar.gz) [Succeeded]
INFO [extract-release-distributions                            ] BEG end-operation
INFO [extract-release-distributions                            ] END end-operation [Succeeded]
INFO [extract-release-distributions                            ] BEG prom-metrics
INFO [extract-release-distributions                            ] END extract-release-distributions [Succeeded]
INFO [extract-release-distributions                            ] END prom-metrics [Succeeded]
INFO [STAGE: process-media                                     ] END Succeeded in 0:03:57
INFO [IUF SESSION: test-arka-021225-fqn7f                      ] END Completed at 2025-12-02 11:05:06.489666
INFO [ACTIVITY: test-arka-021225                               ] END Completed in 0:04:08
----------------
Install Summary
command line: iuf -a test-arka-021225 -m /etc/cray/upgrade/csm/iuf-blr run -r process-media
activity: test-arka-021225
media dir: /etc/cray/upgrade/csm/iuf-blr
state dir: /etc/cray/upgrade/csm/iuf/test-arka-021225/state
log dir: /etc/cray/upgrade/csm/iuf/test-arka-021225/log/20251202110058
site vars: /etc/cray/upgrade/csm/iuf/test-arka-021225/state/session_vars.yaml
----------------
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch orrect
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

